### PR TITLE
Feature/connection options

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-site :opscode
+source 'https://supermarket.chef.io'
 
 metadata

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ adapter                    | Database adapter                                   
 contexts                   | Contexts to run the migrations in                                                                                   | String  | live
 cwd                        | The directory to run the migrations from                                                                            | String  | 
 change_log_properties      | A hash where the keys are property names and the values are property values for substitution into the change log(s) | Hash    | {}
+
+Unless a key named `url` in the `connection` hash is present, the JDBC URL is built from the `adapter` property and the values of `host`, `port`, and `database` in the `connection` property hash.
+If `connection_options` is not `nil`, each key pair is added to the end of the JDBC URL like URL parameters.
+When `url` is present in the `connection` hash, this value is used instead and the value of `adapter` and all other values of keys in `connection` are ignored.

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       "Riot Games"
 maintainer_email "bluepojo@gmail.com"
 license          "Apache 2.0"
 description      "Installs and configures Liquibase"
-version          "1.0.0"
+version          "1.1.0"
 
 %w{ centos redhat fedora }.each do |os|
   supports os

--- a/providers/migrate.rb
+++ b/providers/migrate.rb
@@ -87,7 +87,7 @@ private
       "--driver=#{Shellwords.escape(new_resource.driver)}",
       "--classpath=#{Shellwords.escape(new_resource.classpath)}",
       "--changeLogFile=#{Shellwords.escape(new_resource.change_log_file)}",
-      "--url=#{Shellwords.escape(new_resource.connection_url)}",
+      "--url=#{new_resource.connection_url}",
       "--username=#{Shellwords.escape(new_resource.connection[:username])}",
       "--password=#{Shellwords.escape(new_resource.connection[:password])}"
     ]

--- a/providers/migrate.rb
+++ b/providers/migrate.rb
@@ -76,7 +76,7 @@ private
 
   def liquibase_cmd(*args)
     options = default_options + args + change_log_properties
-    Mixlib::ShellOut.new(options, :env => {'LC_ALL' => 'en_US.UTF-8'} ,:cwd => new_resource.cwd)
+    Mixlib::ShellOut.new(options.join(' '), :env => {'LC_ALL' => 'en_US.UTF-8'} ,:cwd => new_resource.cwd)
   end
   
   def default_options
@@ -87,7 +87,7 @@ private
       "--driver=#{Shellwords.escape(new_resource.driver)}",
       "--classpath=#{Shellwords.escape(new_resource.classpath)}",
       "--changeLogFile=#{Shellwords.escape(new_resource.change_log_file)}",
-      "--url=#{new_resource.connection_url}",
+      "--url=#{Shellwords.escape(new_resource.connection_url)}",
       "--username=#{Shellwords.escape(new_resource.connection[:username])}",
       "--password=#{Shellwords.escape(new_resource.connection[:password])}"
     ]

--- a/resources/migrate.rb
+++ b/resources/migrate.rb
@@ -37,5 +37,10 @@ def initialize(*args)
 end
 
 def connection_url
-  "jdbc:#{adapter}://#{connection[:host]}:#{connection[:port]}/#{connection[:database]}"
+  "jdbc:#{adapter}://#{connection[:host]}:#{connection[:port]}/#{connection[:database]}#{connection_options}"
+end
+
+def connection_options
+  return '' if connection[:options].nil?
+  '?' + connection[:options].join('&')
 end

--- a/resources/migrate.rb
+++ b/resources/migrate.rb
@@ -24,6 +24,7 @@ actions :run, :force
 attribute :change_log_file,       :kind_of => String, :name_attribute => true
 attribute :jar,                   :kind_of => String
 attribute :connection,            :kind_of => Hash, :required => true
+attribute :connection_options,    :kind_of => Hash
 attribute :classpath,             :kind_of => String, :required => true
 attribute :driver,                :kind_of => String, :default => "com.mysql.jdbc.Driver"
 attribute :adapter,               :kind_of => Symbol, :default => :mysql
@@ -37,10 +38,10 @@ def initialize(*args)
 end
 
 def connection_url
-  connection[:url] || "jdbc:#{adapter}://#{connection[:host]}:#{connection[:port]}/#{connection[:database]}#{connection_options}"
+  connection[:url] || "jdbc:#{adapter}://#{connection[:host]}:#{connection[:port]}/#{connection[:database]}#{build_connection_options}"
 end
 
-def connection_options
-  return '' if connection[:options].nil?
-  '?' + connection[:options].map{|k,v| "#{k}=#{v}" }.join('&')
+def build_connection_options
+  return '' if connection_options.nil?
+  '?' + connection_options.map{|k,v| "#{k}=#{v}" }.join('&')
 end

--- a/resources/migrate.rb
+++ b/resources/migrate.rb
@@ -37,10 +37,10 @@ def initialize(*args)
 end
 
 def connection_url
-  "jdbc:#{adapter}://#{connection[:host]}:#{connection[:port]}/#{connection[:database]}#{connection_options}"
+  connection[:url] || "jdbc:#{adapter}://#{connection[:host]}:#{connection[:port]}/#{connection[:database]}#{connection_options}"
 end
 
 def connection_options
   return '' if connection[:options].nil?
-  '?' + connection[:options].join('&')
+  '?' + connection[:options].map{|k,v| "#{k}=#{v}" }.join('&')
 end


### PR DESCRIPTION
Add ability to add options as URL parameters to the JDBC URL or specify the entire URL yourself. Fix shellouts that result in actions taken by `Shellwords.escape`. Include detail on how the JDBC URL is built in the README. 